### PR TITLE
Extends PDF processing timeout to 5 minutes

### DIFF
--- a/src/core/services/messages/process-messages.service.ts
+++ b/src/core/services/messages/process-messages.service.ts
@@ -30,7 +30,7 @@ const PROCESSING_TIMEOUTS = {
   TXT: 10000,
   IMAGE: 30000,
   DOCX: 20000,
-  PDF_GLOBAL: 150000,
+  PDF_GLOBAL: 300000, // 5 minutes timeout
   OPENAI: 25000,
 } as const;
 


### PR DESCRIPTION
Increases the timeout for global PDF processing to accommodate
larger or more complex files that require additional time,
reducing the likelihood of premature timeouts.
