### PR TITLE
Removes transcript filename header from output

### DIFF
--- a/src/core/services/messages/process-messages.service.ts
+++ b/src/core/services/messages/process-messages.service.ts
@@ -89,12 +89,9 @@ export class ProcessMessagesService {
           return { fileId: file.fileId, error: result.error.message, success: false };
         }
 
-        const fileName = path.basename(new URL(file.url).pathname);
-        const header = `## Transcricao do arquivo: ${fileName}:\n\n`;
-
         return {
           fileId: file.fileId,
-          text: header + result.value,
+          text: result.value,
           success: true,
         };
       });


### PR DESCRIPTION
Simplifies returned transcript text by excluding the filename header,
providing cleaner output for downstream usage and improving readability.
