### PR TITLE
fix(ocr): Lower file-size threshold to catch mixed-content PDFs

### DIFF
--- a/src/core/services/messages/pdf-utils/process-pdf.service.ts
+++ b/src/core/services/messages/pdf-utils/process-pdf.service.ts
@@ -142,7 +142,7 @@ export class ProcessPdfService {
     } else if (shouldSkipOcr) {
       if (hasStrongDirectText && qualityAnalysis.hasOcrIndicators) {
         const bytesPerPage = downloadedFile.buffer.byteLength / totalPages;
-        const fileSizeThresholdPerPage = 100_000;
+        const fileSizeThresholdPerPage = 50_000;
         const looksLikeScannedDoc = bytesPerPage > fileSizeThresholdPerPage;
 
         logger.info('PDF file-size heuristic', {


### PR DESCRIPTION
50KB/page instead of 100KB/page correctly identifies PDFs that contain
a mix of text and image pages (e.g. 61KB/page) while still skipping
pure text PDFs (e.g. 10KB/page).

Co-Authored-By: Claude <noreply@anthropic.com>
